### PR TITLE
Dbt dim layer

### DIFF
--- a/ingestion/resources.py
+++ b/ingestion/resources.py
@@ -51,11 +51,11 @@ def load_grocery_classifications():
         d = _api_factory("klassificeringar", item)
         yield d
 
-# ravaror /api/v{version}/livsmedel/{nummer}/ravaror # materials
-@dlt.resource(table_name="raw_material", write_disposition="replace")
-def load_grocery_materials():
+# ravaror /api/v{version}/livsmedel/{nummer}/ravaror # components / raw materials
+@dlt.resource(table_name="raw_component", write_disposition="replace")
+def load_grocery_components():
     """
-    Fetches material information for a specific grocery item from Livsmedelsverket.
+    Fetches component information for a specific grocery item from Livsmedelsverket.
     """
     data = s.get(url=BASE_URL+"/api/v1/livsmedel", params={"limit": 2600}).json()
     for item in data["livsmedel"]:
@@ -76,5 +76,5 @@ def load_grocery_ingredients():
 # Source handles the order for each resource, wich should run first.. etc
 @dlt.source(name="grocery_api")
 def grocery_resources():
-    return [load_groceries(), load_grocery_nutrients(), load_grocery_classifications(), load_grocery_materials(), load_grocery_ingredients()]
+    return [load_groceries(), load_grocery_nutrients(), load_grocery_classifications(), load_grocery_components(), load_grocery_ingredients()]
 

--- a/mealplanner_dbt/.gitignore
+++ b/mealplanner_dbt/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_packages/
 logs/
+package-lock.yml

--- a/mealplanner_dbt/dbt_project.yml
+++ b/mealplanner_dbt/dbt_project.yml
@@ -29,5 +29,12 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   mealplanner_dbt:
     +materialized: view
+
     staging:
       schema: staging
+
+    dim:
+      schema: refined
+
+    fct:
+      schema: refined

--- a/mealplanner_dbt/models/dim/dim_classification.sql
+++ b/mealplanner_dbt/models/dim/dim_classification.sql
@@ -1,0 +1,15 @@
+WITH stg_classification AS (
+    SELECT * FROM {{ ref ('stg_classification') }}
+)
+
+SELECT DISTINCT
+    {{ dbt_utils.generate_surrogate_key([
+    'facet_code',
+    'facet_name'
+    ]) }} AS id,
+    description,
+    facet_code,
+    facet_name,
+    type
+
+FROM stg_classification

--- a/mealplanner_dbt/models/dim/dim_component.sql
+++ b/mealplanner_dbt/models/dim/dim_component.sql
@@ -1,0 +1,17 @@
+WITH stg_component AS (
+    SELECT * FROM {{ ref ('stg_component') }}
+)
+
+SELECT DISTINCT
+    {{ dbt_utils.generate_surrogate_key([
+    'ex2_code',
+    'name'
+    ]) }} AS id,
+    ex2_code,
+    name,
+    cooking_style,
+    final_share,
+    factor,
+    raw_share    
+
+FROM stg_component

--- a/mealplanner_dbt/models/dim/dim_grocery.sql
+++ b/mealplanner_dbt/models/dim/dim_grocery.sql
@@ -1,0 +1,14 @@
+WITH stg_grocery AS (
+    SELECT * FROM {{ ref ('stg_grocery') }}
+)
+
+SELECT DISTINCT
+    {{ dbt_utils.generate_surrogate_key([
+    'number',
+    'name'
+    ]) }} AS id,
+    number,
+    name,
+    version
+
+FROM stg_grocery

--- a/mealplanner_dbt/models/dim/dim_ingredient.sql
+++ b/mealplanner_dbt/models/dim/dim_ingredient.sql
@@ -1,0 +1,18 @@
+WITH stg_ingredient AS (
+    SELECT * FROM {{ ref ('stg_ingredient') }}
+)
+
+SELECT DISTINCT
+    {{ dbt_utils.generate_surrogate_key([
+    'number',
+    'name'
+    ]) }} AS id,
+    number,
+    name,
+    water_weight_change_factor,
+    fat_weight_change_factor,
+    weight_before_cooking,
+    weight_after_cooking,
+    yield_factor_name
+
+FROM stg_ingredient

--- a/mealplanner_dbt/models/dim/dim_nutrient.sql
+++ b/mealplanner_dbt/models/dim/dim_nutrient.sql
@@ -1,0 +1,14 @@
+WITH stg_nutrient AS (
+    SELECT * FROM {{ ref ('stg_nutrient') }}
+)
+
+SELECT DISTINCT
+    {{ dbt_utils.generate_surrogate_key([
+    'name',
+    'abbreviation'
+    ]) }} AS id,
+    name,
+    abbreviation,
+    measurement_unit
+
+FROM stg_nutrient

--- a/mealplanner_dbt/models/staging/sources.yml
+++ b/mealplanner_dbt/models/staging/sources.yml
@@ -10,6 +10,6 @@ sources:
       - name: raw_classification
         description: "Classification categories for a food item."
       - name: raw_ingredient
-        description: "Ingredient composition for a food item."
-      - name: raw_material
-        description: "Raw agricultural commodities linked to a food item."
+        description: "Ingredient composition for a food item (label-level)."
+      - name: raw_component
+        description: "Underlying raw materials/components used for nutrient calculations."

--- a/mealplanner_dbt/models/staging/stg_classification.sql
+++ b/mealplanner_dbt/models/staging/stg_classification.sql
@@ -1,8 +1,8 @@
 SELECT 
-  grocery_number AS grocery_id,
+  grocery_number,
   langual_id,
   namn AS description,
   fasettkod AS facet_code,
   fasett AS facet_name,
-  typ AS type,
+  typ AS type
 FROM {{ source ('livsmedelsverket', 'raw_classification') }} 

--- a/mealplanner_dbt/models/staging/stg_component.sql
+++ b/mealplanner_dbt/models/staging/stg_component.sql
@@ -1,9 +1,9 @@
 SELECT 
-  grocery_number AS grocery_id,
+  grocery_number,
   food_ex2 AS ex2_code,
   namn AS name,
   tillagning AS cooking_style,
   andel AS final_share,
   faktor AS factor,
   omraknad_till_ra AS raw_share
-FROM {{ source ('livsmedelsverket', 'raw_material') }} 
+FROM {{ source ('livsmedelsverket', 'raw_component') }} 

--- a/mealplanner_dbt/models/staging/stg_grocery.sql
+++ b/mealplanner_dbt/models/staging/stg_grocery.sql
@@ -1,5 +1,5 @@
 SELECT 
-  nummer AS id,
+  nummer AS number,
   namn AS name,
-  version,
+  version
 FROM {{ source ('livsmedelsverket', 'raw_grocery') }} 

--- a/mealplanner_dbt/models/staging/stg_ingredient.sql
+++ b/mealplanner_dbt/models/staging/stg_ingredient.sql
@@ -1,10 +1,10 @@
 SELECT 
-  nummer AS ingredient_id,
+  nummer AS number,
   namn AS name,
-  vatten_faktor AS water_factor,
-  fett_faktor AS fat_factor,
-  vikt_fore_tillagning AS weight_prior_to_cooking,
-  vikt_efter_tillagning AS weight_post_cooking,
-  tillagningsfaktor AS cooking_factor,
-  grocery_number AS grocery_id,
+  vatten_faktor AS water_weight_change_factor,
+  fett_faktor AS fat_weight_change_factor,
+  vikt_fore_tillagning AS weight_before_cooking,
+  vikt_efter_tillagning AS weight_after_cooking,
+  tillagningsfaktor AS yield_factor_name,
+  grocery_number
 FROM {{ source ('livsmedelsverket', 'raw_ingredient') }} 

--- a/mealplanner_dbt/models/staging/stg_nutrient.sql
+++ b/mealplanner_dbt/models/staging/stg_nutrient.sql
@@ -1,13 +1,13 @@
 SELECT 
-  grocery_number AS grocery_id,
+  grocery_number,
   namn AS name,
   euro_fi_rkod AS euro_fir_code,
-  forkortning AS abreviation,
+  forkortning AS abbreviation,
   varde AS value,
-  enhet AS unit_type,
+  enhet AS measurement_unit,
   vikt_gram AS weight_gram,
   matrisenhet AS matrix_unit,
   matrisenhetkod AS matrix_unit_code,
   berakning AS calculation,
-  vardetyp AS value_type,
+  vardetyp AS value_type
 FROM {{ source ('livsmedelsverket', 'raw_nutrient') }} 

--- a/mealplanner_dbt/packages.yml
+++ b/mealplanner_dbt/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0


### PR DESCRIPTION
## 🎯 What's This?
Adds the dimension layer models for the mealplanner project.  
Includes dim_grocery, dim_ingredient, dim_component, dim_classification, and dim_nutrient.  
These models standardize the source tables and create surrogate keys for consistent joins in fact tables.

## 🔗 Issue
Closes #9 

## 🧪 Test It
1. Run `dbt build --select dim_*` locally or in the dev environment.  
2. Verify all dim tables are created correctly with expected row counts.  
3. Check that surrogate keys are unique and match the expected number of distinct source rows.

## 📸 Screenshot
N/A — no UI changes.

## 💭 Notes
- This PR only adds the dimension layer models.  
- Fact tables (fct_grocery_*) are not included in this PR; they will be in a separate PR.
- Renamed "material(s)" to "component" for clarity.
