### PR TITLE
REFACTOR(dbt-models): Purify dimension and fact tables

### DIFF
--- a/mealplanner_dbt/models/dim/dim_classification.sql
+++ b/mealplanner_dbt/models/dim/dim_classification.sql
@@ -1,3 +1,4 @@
+-- dim_classification.sql
 WITH stg_classification AS (
     SELECT * FROM {{ ref ('stg_classification') }}
 )
@@ -7,9 +8,6 @@ SELECT DISTINCT
     'facet_code',
     'facet_name'
     ]) }} AS id,
-    description,
     facet_code,
     facet_name,
-    type
-
 FROM stg_classification

--- a/mealplanner_dbt/models/dim/dim_component.sql
+++ b/mealplanner_dbt/models/dim/dim_component.sql
@@ -1,17 +1,10 @@
+-- dim_component.sql
 WITH stg_component AS (
     SELECT * FROM {{ ref ('stg_component') }}
 )
 
 SELECT DISTINCT
-    {{ dbt_utils.generate_surrogate_key([
-    'ex2_code',
-    'name'
-    ]) }} AS id,
+    {{ dbt_utils.generate_surrogate_key(['ex2_code','name']) }} AS id,
     ex2_code,
-    name,
-    cooking_style,
-    final_share,
-    factor,
-    raw_share    
-
+    name
 FROM stg_component

--- a/mealplanner_dbt/models/dim/dim_grocery.sql
+++ b/mealplanner_dbt/models/dim/dim_grocery.sql
@@ -1,3 +1,4 @@
+-- dim_grocery.sql
 WITH stg_grocery AS (
     SELECT * FROM {{ ref ('stg_grocery') }}
 )

--- a/mealplanner_dbt/models/dim/dim_ingredient.sql
+++ b/mealplanner_dbt/models/dim/dim_ingredient.sql
@@ -1,3 +1,4 @@
+-- dim_ingredient.sql
 WITH stg_ingredient AS (
     SELECT * FROM {{ ref ('stg_ingredient') }}
 )
@@ -9,10 +10,4 @@ SELECT DISTINCT
     ]) }} AS id,
     number,
     name,
-    water_weight_change_factor,
-    fat_weight_change_factor,
-    weight_before_cooking,
-    weight_after_cooking,
-    yield_factor_name
-
 FROM stg_ingredient

--- a/mealplanner_dbt/models/dim/dim_nutrient.sql
+++ b/mealplanner_dbt/models/dim/dim_nutrient.sql
@@ -1,3 +1,4 @@
+-- dim_nutrient.sql
 WITH stg_nutrient AS (
     SELECT * FROM {{ ref ('stg_nutrient') }}
 )
@@ -5,7 +6,8 @@ WITH stg_nutrient AS (
 SELECT DISTINCT
     {{ dbt_utils.generate_surrogate_key([
     'name',
-    'abbreviation'
+    'abbreviation',
+    'measurement_unit'
     ]) }} AS id,
     name,
     abbreviation,

--- a/mealplanner_dbt/models/fct/fct_grocery_classification.sql
+++ b/mealplanner_dbt/models/fct/fct_grocery_classification.sql
@@ -1,3 +1,4 @@
+-- fct_grocery_classification.sql
 WITH stg_classification AS (
     SELECT * FROM {{ ref('stg_classification') }}
 ),
@@ -7,7 +8,7 @@ dim_grocery AS (
 ),
 
 dim_classification AS (
-    SELECT facet_code, id AS classification_id FROM {{ ref('dim_classification') }}
+    SELECT facet_code, facet_name, id AS classification_id FROM {{ ref('dim_classification') }}
 )
 
 SELECT 
@@ -17,4 +18,6 @@ SELECT
     sc.type
 FROM stg_classification sc
 JOIN dim_grocery dg ON sc.grocery_number = dg.number
-JOIN dim_classification dc ON sc.facet_code = dc.facet_code
+JOIN dim_classification dc ON 
+            sc.facet_code = dc.facet_code and
+            sc.facet_name = dc.facet_name

--- a/mealplanner_dbt/models/fct/fct_grocery_component.sql
+++ b/mealplanner_dbt/models/fct/fct_grocery_component.sql
@@ -1,3 +1,4 @@
+-- fct_grocery_component.sql 
 WITH stg_component AS (
     SELECT * FROM {{ ref('stg_component') }}
 ),
@@ -7,10 +8,10 @@ dim_grocery AS (
 ),
 
 dim_component AS (
-    SELECT ex2_code, id AS component_id FROM {{ ref('dim_component') }}
+    SELECT ex2_code, name, id AS component_id FROM {{ ref('dim_component') }}
 )
 
-SELECT 
+SELECT
     dg.grocery_id,
     dc.component_id,
     sc.final_share,
@@ -19,4 +20,6 @@ SELECT
     sc.cooking_style
 FROM stg_component sc
 JOIN dim_grocery dg ON sc.grocery_number = dg.number
-JOIN dim_component dc ON sc.ex2_code = dc.ex2_code
+JOIN dim_component dc ON
+    sc.ex2_code = dc.ex2_code and
+    sc.name = dc.name

--- a/mealplanner_dbt/models/fct/fct_grocery_ingredient.sql
+++ b/mealplanner_dbt/models/fct/fct_grocery_ingredient.sql
@@ -1,3 +1,4 @@
+-- fct_grocery_ingredient.sql
 WITH stg_ingredient AS (
     SELECT * FROM {{ ref('stg_ingredient') }}
 ),
@@ -20,4 +21,6 @@ SELECT
     si.yield_factor_name             AS ingredient_yield_factor_name
 FROM stg_ingredient si
 JOIN dim_grocery dg ON si.grocery_number = dg.number
-JOIN dim_ingredient di ON si.name = di.name
+JOIN dim_ingredient di ON 
+                        si.name = di.name and 
+                        si.number = di.number

--- a/mealplanner_dbt/models/fct/fct_grocery_nutrient.sql
+++ b/mealplanner_dbt/models/fct/fct_grocery_nutrient.sql
@@ -1,3 +1,4 @@
+-- fct_grocery_nutrient.sql
 WITH stg_nutrient AS (
     SELECT * FROM {{ ref('stg_nutrient') }}
 ),
@@ -7,14 +8,17 @@ dim_grocery AS (
 ),
 
 dim_nutrient AS (
-    SELECT name, abbreviation, id AS nutrient_id FROM {{ ref('dim_nutrient') }}
+    SELECT name, abbreviation, measurement_unit, id AS nutrient_id FROM {{ ref('dim_nutrient') }}
 )
 
 SELECT 
     dg.grocery_id,
     dn.nutrient_id,
-    sn.value                AS nutrient_value,
-    sn.measurement_unit     AS nutrient_measurement_unit
-FROM stg_nutrient sn
-JOIN dim_grocery dg on sn.grocery_number = dg.number
-JOIN dim_nutrient dn on sn.name = dn.name
+    sn.value          AS nutrient_value,
+FROM stg_nutrient AS sn
+JOIN dim_grocery AS dg on sn.grocery_number = dg.number
+-- This below is to mirror the surrogate key in dim_nutrient
+JOIN dim_nutrient AS dn on 
+            sn.name = dn.name and
+            sn.abbreviation = dn.abbreviation and
+            sn.measurement_unit = dn.measurement_unit

--- a/mealplanner_dbt/models/staging/stg_nutrient.sql
+++ b/mealplanner_dbt/models/staging/stg_nutrient.sql
@@ -1,3 +1,4 @@
+-- stg_nutrient.sql
 SELECT 
   grocery_number,
   namn AS name,


### PR DESCRIPTION
## What's This?

This PR refactors the core dbt data models to implement a proper star schema. The main goal was to purify the dimension tables and ensure a clear separation of concerns between dimensions and facts.

Key changes include:
-   **Purified Dimension Tables (`dim_*`):** All dimension tables have been cleaned up to only contain attributes that describe the entity itself (e.g., `dim_ingredient` now only contains `id`, `number`, and `name`). All measures and metrics have been removed.
-   **Consolidated Fact Tables (`fct_*`):** All measures, factors, and metrics (e.g., `weight_before_cooking`, `final_share`) have been moved to their respective fact tables.
-   **Robust Join Logic:** The join conditions in all fact tables have been updated to use the full composite natural key, ensuring data integrity and preventing potential fan-outs.

This results in a cleaner, more maintainable, and logically correct data model that is easier to query and build upon.

## Issue

Closes #29 

## Test It

To verify the changes, a reviewer should:
1.  Check out this branch (`dbt-model-update`).
2.  Run `dbt clean`, `dbt deps` and `dbt build` and ensure all models complete successfully.
3.  Inspect the resulting tables in the data warehouse:
    -   Verify that `dim_*` tables are now lean and only contain descriptive attributes.
    -   Verify that `fct_*` tables contain the foreign keys (`_id`) and all the relevant measures.

## Screenshot

N/A - Changes are purely in the data model logic.

## Notes

This refactoring establishes a clear and consistent pattern for our data models going forward:
-   **Dimensions** describe *what something is*.
-   **Facts** describe *what something does or has*.

All future models should adhere to this principle.